### PR TITLE
Allow using rust-tls instead of native-tls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ license = "AGPL-3.0-only"
 edition = "2021"
 repository = "https://github.com/Juris-Power/brevo-rust"
 
+[features]
+rust-tls = ["reqwest/rustls-tls"]
+
 [dependencies]
 serde = { version = "^1.0", features = ["derive"] }
 serde_with = { version = "^3.8", default-features = false, features = ["base64", "std", "macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 repository = "https://github.com/Juris-Power/brevo-rust"
 
 [features]
-default = ["native-tls"]  # Or leave empty to force consumers to choose
+default = ["native-tls"]
 rust-tls = ["reqwest/rustls-tls"]
 native-tls = ["reqwest/native-tls"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,9 @@ edition = "2021"
 repository = "https://github.com/Juris-Power/brevo-rust"
 
 [features]
+default = ["native-tls"]  # Or leave empty to force consumers to choose
 rust-tls = ["reqwest/rustls-tls"]
+native-tls = ["reqwest/native-tls"]
 
 [dependencies]
 serde = { version = "^1.0", features = ["derive"] }
@@ -21,4 +23,4 @@ serde_json = "^1.0"
 serde_repr = "^0.1"
 url = "^2.5"
 uuid = { version = "^1.8", features = ["serde", "v4"] }
-reqwest = { version = "^0.12", features = ["json", "multipart"] }
+reqwest = { version = "^0.12", default-features = false, features = ["json", "multipart", "charset"] }


### PR DESCRIPTION
This allow users of the library to configure:
```
default-features = false, features = ["rust-tls"]
```

and be openssl-sys free (via reqwest)

By default normal behaviour is unchanged and native-tls from reqwest is used